### PR TITLE
feat: do RTCM message reassembly within the driver itself

### DIFF
--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -151,6 +151,18 @@ Frame Driver::readFrame()
     return waitForPacket();
 }
 
+void Driver::writeRTCM(std::vector<uint8_t> const& data) {
+    mRTCMReassembly.push(data);
+    while(true) {
+        vector<uint8_t> message = mRTCMReassembly.pull();
+        if (message.empty()) {
+            return;
+        }
+
+        writePacket(message.data(), message.size());
+    }
+}
+
 Frame Driver::waitForFrame(uint8_t class_id, uint8_t msg_id)
 {
     return waitForPacket(&class_id, &msg_id);

--- a/src/Driver.hpp
+++ b/src/Driver.hpp
@@ -9,6 +9,8 @@
 #include <gps_ublox/SatelliteInfo.hpp>
 #include <gps_ublox/SignalInfo.hpp>
 #include <gps_ublox/UBX.hpp>
+
+#include <gps_base/RTCMReassembly.hpp>
 #include <iodrivers_base/Driver.hpp>
 
 namespace gps_ublox
@@ -46,6 +48,8 @@ namespace gps_ublox
                                      const std::vector<uint8_t> *payload = nullptr);
             bool waitForAck(uint8_t class_id, uint8_t msg_id);
             void pollOneFrame(PollCallbacks& callbacks, base::Time const& timeout);
+
+            gps_base::RTCMReassembly mRTCMReassembly;
 
         protected:
             /** Implements iodrivers_base's extractPacket protocol
@@ -246,6 +250,13 @@ namespace gps_ublox
              * \c setPortProtocol
              */
             void poll(PollCallbacks& callbacks);
+
+            /** Write RTCM data to the device
+             *
+             * The data does not have to be cmoplete RTCM messages, the driver
+             * will internally reassemble full messages before sending them
+             */
+            void writeRTCM(std::vector<uint8_t> const& data);
     };
 
 } // end namespace gps_ublox

--- a/test/test_RTKInfo.cpp
+++ b/test/test_RTKInfo.cpp
@@ -13,6 +13,7 @@ TEST_F(RTKInfoTest, update_sets_time_from_PVT_time) {
     RTKInfo info;
     PVT pvt;
     pvt.time = base::Time::now();
+    pvt.fix_flags = 0;
     info.update(pvt);
     ASSERT_EQ(pvt.time, info.time);
 }


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-drivers/drivers-gps_base/pull/15

This is a common need, so instead of requiring each source to
do it first let's have the driver handle it (since it is a requirement
from its side).