### PR TITLE
fix: set read/write timeouts to 5s in gps_ublox_ctl

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -332,8 +332,8 @@ int main(int argc, char** argv)
     string cmd(argv[2]);
 
     Driver driver;
-    driver.setReadTimeout(base::Time::fromMilliseconds(100));
-    driver.setWriteTimeout(base::Time::fromMilliseconds(100));
+    driver.setReadTimeout(base::Time::fromMilliseconds(5000));
+    driver.setWriteTimeout(base::Time::fromMilliseconds(5000));
 
     if (cmd == "reset") {
         driver.openURI(uri);


### PR DESCRIPTION
100ms timeout is low for slow serial line / other links. I had timeouts on 19200 bauds with 100ms

Speed is not really of the essence for this tool, so pick a much higher timeout.