### PR TITLE
fix: test against PPS_CANWAIT in pps caps instead of params

### DIFF
--- a/src/chrony.cpp
+++ b/src/chrony.cpp
@@ -115,13 +115,13 @@ PPS PPS::open(std::string const& path)
         throw std::runtime_error(
             "pps " + path + " does not support capturing the rising edge");
     }
+    if (!(mode & PPS_CANWAIT)) {
+        throw std::runtime_error("need a PPS that has CANWAIT support");
+    }
 
     pps_params_t params;
     if (time_pps_getparams(handle, &params) < 0) {
         throw UnixError("could not query PPS params for " + path);
-    }
-    if (!(params.mode & PPS_CANWAIT)) {
-        throw std::runtime_error("need a PPS that has CANWAIT support");
     }
 
     params.mode |= PPS_CAPTUREASSERT;


### PR DESCRIPTION
The spec says params but it is readonly (which is ... weird), but it seems that it should really be checked in the caps. It does make more sense, and it is what gpsd does.

The params PPS_CANWAIT is cleared on boot on BBBs, but appears magically once chrony ran at least once. My guess is that it appears after the type of assertions has been configured.
