### PR TITLE
fix: reject outlier timepulse values coming from ublox

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -627,14 +627,23 @@ int main(int argc, char** argv)
                         continue;
                     }
 
+                    std::cout
+                        << "pulse next utc=" << tp.time()
+                        << " received at time=" << tp.timestamp << ", "
+                        << "flags=" << hex << static_cast<int>(tp.flags)
+                        << dec;
+
+                    if (tp.time_of_week.toMilliseconds() % 1000 != 0) {
+                        std::cout << " REJECTED" << std::endl;
+                        continue;
+                    }
+
+
+                    std::cout << " ACCEPTED" << std::endl;
                     {
                         lock_guard<mutex> guard(last_tp_mutex);
                         last_tp = tp;
                     }
-
-                    std::cout
-                        << "pulse next utc=" << tp.time()
-                        << " received at time=" << tp.timestamp << std::endl;
                 }
             }
             catch(std::runtime_error& e) {


### PR DESCRIPTION
Add the `flags` field, as it may be relevant to filter them out in a more robust way (not very clear from documentation how)
